### PR TITLE
Fix: Restructure Statbox Data

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -2,18 +2,18 @@
 
 function update_file()
 dset(1, stat_box.available_exp)
-dset(2, stat_box.stats[2])
-dset(3, stat_box.stats[4])
-dset(4, stat_box.stats[6])
-dset(5, stat_box.stats[8])
+dset(2, stats[1].level)
+dset(3, stats[2].level)
+dset(4, stats[3].level)
+dset(5, stats[4].level)
 end
 
 function load_file()
 stat_box.available_exp = dget(1)
-stat_box.stats[2] = dget(2)
-stat_box.stats[4] = dget(3)
-stat_box.stats[6] = dget(4)
-stat_box.stats[8] = dget(5)
+stats[1].level = dget(2)
+stats[2].level = dget(3)
+stats[3].level = dget(4)
+stats[4].level = dget(5)
 end
 
 function set_file_defaults()

--- a/gameloop/_init.lua
+++ b/gameloop/_init.lua
@@ -57,12 +57,13 @@ stat_box = {
     pet_name="octopet",
     stat_index = 0,
     available_exp = 0,
-    stats = {
-        "♥ health", 0,
-        "▒ speed",  0,
-        "✽ suction",0,
-        "∧ stretch",0
-    }
+}
+
+stats = {
+  {name="health", level=0, symbol="♥"},
+  {name="speed", level=0, symbol="▒"},
+  {name="suction", level=0, symbol="✽"},
+  {name="stretch", level=0, symbol="∧"}
 }
 
 -- shop
@@ -102,14 +103,4 @@ pupil_script      = {{0,0},{-4,0},{4,-4}}
 
 body_shift_ai     = 0
 body_shift_state  = 0
-end
-
-function error(val)
-  if val == nil then
-    error = "empty message (default)"
-  else
-    error = val
-  end
-
-  state = "debug"
 end

--- a/states/stat_menu.lua
+++ b/states/stat_menu.lua
@@ -41,8 +41,7 @@ function make_stat_box()
    stat_box.clr)
 
   -- draw text in statbox
-
-  local stat_index = 1
+  stat_index = 1
 
   print(
    stat_box.pet_name,
@@ -52,17 +51,19 @@ function make_stat_box()
 
   stat_index += 1
 
-  for v in all(stat_box.stats) do
-    local val = v
-    if type(val) == "number" then
-      val = make_exp_bar(val)
-    end
-    print(val,
-     stat_box.x0+4,
-     stat_box.y0+(6*stat_index),
-     text_color_inv)
+  for stat in all(stats) do
+    print_formatted_stat(stat.symbol..stat.name..stat.symbol)
+    stat_index += 1
+    print_formatted_stat(make_exp_bar(stat.level))
     stat_index += 1
   end
+end
+
+function print_formatted_stat(val)
+  print(val,
+        stat_box.x0+4,
+        stat_box.y0+(6*stat_index),
+        text_color_inv)
 end
 
 function make_exp_bar(exp)

--- a/states/world.lua
+++ b/states/world.lua
@@ -24,7 +24,7 @@ function get_collisions()
 end
 
 function circ_rect_intersect(p)
-  local r = stat_box.stats[6]
+  local r = stats[3].level
   circ_dis_x = abs(world_pet.x-p.x)
   circ_dis_y = abs(world_pet.y-p.y)
 

--- a/update.lua
+++ b/update.lua
@@ -89,14 +89,14 @@ function update_stat_menu()
     stat_box.stat_index -= 1
   end
 
-  local off_index = 2 * stat_box.stat_index + 2
+  local off_index = stat_box.stat_index + 1
   -- exp increment logic
   if not cursor_on_pet and
    btnp(❎) and
    stat_box.available_exp > 0 and
-   stat_box.stats[off_index] < 7 then
+   stats[off_index].level < 7 then
     stat_box.available_exp -= 1
-    stat_box.stats[off_index] += 1
+    stats[off_index].level += 1
     update_file()
   elseif btnp(❎) then
     sway_pet_startpoint(3)


### PR DESCRIPTION
This fix restructures the stat data so it is easier to work with. The stats table has been pulled outside of the stat_box table to make the depth of the nesting structure one table deep. As a result several areas needed to be modified to address the restructure. This also removes the need to lookup stat values by their string value.